### PR TITLE
implement syncvector environment

### DIFF
--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -203,28 +203,47 @@ def preprocess_data_generator(challenges: Dict[str, Any], solutions: Dict[str, A
 
 from arc_agi_grid_env import ArcAgiGridEnv
 
+def load_challenges_and_solutions(
+                                    training_challenges_json: str,
+                                    training_solutions_json: str,
+                                    evaluation_challenges_json: str,
+                                    evaluation_solutions_json: str,
+                                    test_challenges_json: str,
+                                    ) -> Tuple:
+    # training, evaluation, test challenge 및 solution들을 불러오기
+    with open(training_challenges_json, 'r', encoding='utf-8') as file:
+        training_challenges = json.load(file)
+    with open(training_solutions_json, 'r', encoding='utf-8') as file:
+        training_solutions = json.load(file)
+    with open(evaluation_challenges_json, 'r', encoding='utf-8') as file:
+        evaluation_challenges = json.load(file)
+    with open(evaluation_solutions_json, 'r', encoding='utf-8') as file:
+        evaluation_solutions = json.load(file)
+    with open(test_challenges_json, 'r', encoding='utf-8') as file:
+        test_challenges = json.load(file)
+    return training_challenges, training_solutions, \
+            evaluation_challenges, evaluation_solutions, test_challenges
+                
+# self.train_task_img_dict, self.train_task_seq_dict = preprocess_data(self.training_challenges, self.training_solutions)
+# self.eval_task_img_dict, self.eval_task_seq_dict = preprocess_data(self.evaluation_challenges, self.evaluation_solutions)
 
 class ArcAgiGridEnvCoord(ArcAgiGridEnv):
     def __init__(self,
-                 training_challenges_json: str,
-                 training_solutions_json: str,
-                 evaluation_challenges_json: str,
-                 evaluation_solutions_json: str,
-                 test_challenges_json: str,
-                 ):
-        # training, evaluation, test challenge 및 solution들을 불러오기
-        with open(training_challenges_json, 'r', encoding='utf-8') as file:
-            self.training_challenges = json.load(file)
-        with open(training_solutions_json, 'r', encoding='utf-8') as file:
-            self.training_solutions = json.load(file)
-        with open(evaluation_challenges_json, 'r', encoding='utf-8') as file:
-            self.evaluation_challenges = json.load(file)
-        with open(evaluation_solutions_json, 'r', encoding='utf-8') as file:
-            self.evaluation_solutions = json.load(file)
-        with open(test_challenges_json, 'r', encoding='utf-8') as file:
-            self.test_challenges = json.load(file)
-        self.train_task_img_dict, self.train_task_seq_dict = preprocess_data(self.training_challenges, self.training_solutions)
-        self.eval_task_img_dict, self.eval_task_seq_dict = preprocess_data(self.evaluation_challenges, self.evaluation_solutions)
+                training_challenges,
+                training_solutions,
+                evaluation_challenges,
+                evaluation_solutions,
+                test_challenges,
+                train_task_img_dict,
+                eval_task_img_dict,
+                ):
+        self.training_challenges = training_challenges
+        self.training_solutions = training_solutions
+        self.evaluation_challenges = evaluation_challenges
+        self.evaluation_solutions = evaluation_solutions
+        self.test_challenges = test_challenges
+        self.train_task_img_dict = train_task_img_dict
+        self.eval_task_img_dict = eval_task_img_dict
         self.train_task_list = list(self.train_task_img_dict.keys())
         self.eval_task_list = list(self.eval_task_img_dict.keys())
 
@@ -251,27 +270,31 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
     def _get_info(self) -> Dict:
         return {
             'target_grid_img': self._target_grid_img,
-            'target_grid_seq': self._target_grid_seq,
             'timestep': self.timestep,
             'task_id': self.task_id,
             'test_input_idx': self.test_input_idx,
             "current_grid_img": self._current_grid_img,
             "chosen_grid_img": self._chosen_grid_img,
-            "current_grid_seq": self._current_grid_seq,
-            "chosen_grid_seq": self._chosen_grid_seq,
         }
 
     def reset(self,
               seed: Optional[int] = None,
               options: Optional[dict] = None):
-        mode = options['mode']
-        task_id = options['task_id']
-        reset_sol_grid = options['reset_sol_grid']
-        
+        task_id = None
+        pair_idx = None
+        if options != None:
+            mode = options['mode']
+            task_id = options['task_id']
+            pair_idx = options['pair_idx']
+            reset_sol_grid = options['reset_sol_grid']
+            self.task_id = task_id
+            self.pair_idx = pair_idx
+    
         self.timestep = 0
         if task_id == None:
             task_id = self._select_task(seed)
-        self.task_id = task_id
+            self.task_id = task_id
+            
         """
         Args:
             seed: Random seed for reproducible episodes
@@ -285,22 +308,24 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         random.seed(seed)
         np.random.seed(seed)
         # task_id에 해당하는 target grid 선택 (test input이 여러 개 존재 가능하므로 한 번 더 random.choice 수행
-        if mode == 'train':
-            test_input_idx = random.choice(list(range(len(self.train_task_img_dict[task_id]))))
-            self._target_grid_img = self.train_task_img_dict[task_id][test_input_idx]
-            self._target_grid_seq = self.train_task_seq_dict[task_id][test_input_idx]
-        elif mode == 'evaluation' or mode == 'eval':
-            test_input_idx = random.choice(list(range(len(self.eval_task_img_dict[task_id]))))
-            self._target_grid_img = self.eval_task_img_dict[task_id][test_input_idx]
-            self._target_grid_seq = self.eval_task_seq_dict[task_id][test_input_idx]
-        self.test_input_idx = test_input_idx
+        if pair_idx == None:
+            if mode == 'train':
+                pair_idx = random.choice(list(range(len(self.train_task_img_dict[task_id]))))
+                self._target_grid_img = self.train_task_img_dict[task_id][pair_idx]
+            elif mode == 'evaluation' or mode == 'eval':
+                pair_idx = random.choice(list(range(len(self.eval_task_img_dict[task_id]))))
+                self._target_grid_img = self.eval_task_img_dict[task_id][pair_idx]
+        else:
+            if mode == 'train':
+                self._target_grid_img = self.train_task_img_dict[task_id][pair_idx]
+            elif mode == 'evaluation' or mode == 'eval':
+                self._target_grid_img = self.eval_task_img_dict[task_id][pair_idx]
+        self.test_input_idx = pair_idx
         # target grid에서 test solution에 해당하는 부분을 전부 pad_val으로 masking하고 current grid로 할당
         if reset_sol_grid == 'padding':
             empty_val = 11
             self._current_grid_img = self._target_grid_img.copy()
             self._current_grid_img[0:30, 150:] = empty_val 
-            self._current_grid_seq = self._target_grid_seq.copy()
-            self._current_grid_seq[4500:] = empty_val
         elif reset_sol_grid == 'random':
             # ! 여기서 solution에 해당하는 부분을 랜덤으로 초기화해도 좋을듯?
             rand_grid = np.random.randint(low=0,
@@ -308,11 +333,8 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
                                             size=(30, 30))
             self._current_grid_img = self._target_grid_img.copy()
             self._current_grid_img[0:30, 150:] = rand_grid
-            self._current_grid_seq = self._target_grid_seq.copy()
-            self._current_grid_seq[4500:] = rand_grid.flatten()
 
         self._chosen_grid_img = np.zeros([30, 30]).astype(int)
-        self._chosen_grid_seq = np.zeros([900]).astype(int)
         observation = self._get_obs()
         info = self._get_info()
         return observation, info
@@ -334,14 +356,10 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         current_cell_value = self._current_grid_img[row, 150+col]
         
         self._current_grid_img[row, 150+col] = color
-        self._current_grid_seq[4500+index] = color
         self._chosen_grid_img[row, col] += 1
-        self._chosen_grid_seq[index] += 1
 
         # Check if agent reached the target
         target_color_img = self._target_grid_img[row, 150+col]
-        target_color_seq = self._target_grid_seq[4500+index]
-        assert target_color_img == target_color_seq
         
         terminated = False
         truncated = False
@@ -511,8 +529,40 @@ class ArcAgiWrapper(Wrapper):
     while maintaining compatibility with Gymnasium's interface.
     """
     
-    def __init__(self, env):
+    def __init__(self, env, 
+                 fixed_task: bool, 
+                 fixed_pair_idx: bool, 
+                task_id: str,
+                pair_idx: int,):
         super().__init__(env)
+        self.fixed_task = fixed_task
+        self.fixed_pair_idx = fixed_pair_idx
+        self.task_id = task_id
+        self.pair_idx = pair_idx
+    
+    def reset(self, *args, **kwargs,):
+        if self.fixed_task and not self.fixed_pair_idx:
+            options = {'mode': 'train',
+                    'task_id': self.task_id, # 794b24be, 3cd86f4f
+                    'pair_idx': None, 
+                    'reset_sol_grid': 'padding',}
+        elif self.fixed_task and self.fixed_pair_idx:
+            options = {'mode': 'train',
+                    'task_id': self.task_id, # 794b24be, 3cd86f4f
+                    'pair_idx': self.pair_idx, 
+                    'reset_sol_grid': 'padding',}
+        elif not self.fixed_task and self.fixed_pair_idx:
+            options = {'mode': 'train',
+                    'task_id': None, # 794b24be, 3cd86f4f
+                    'pair_idx': self.pair_idx, 
+                    'reset_sol_grid': 'padding',}
+        else:
+            options = {'mode': 'train',
+                    'task_id': None, # 794b24be, 3cd86f4f
+                    'pair_idx': None, 
+                    'reset_sol_grid': 'padding',}
+        # task_id를 항상 포함시켜서 reset 호출
+        return self.env.reset(options=options,)
     
     def __getattr__(self, name):
         """
@@ -543,11 +593,20 @@ class ArcAgiWrapper(Wrapper):
     def plot_padded_task(self, task_id, i, w=0.5):
         return self.env.plot_padded_task(task_id, i, w)
 
+
 # 사용 예시
-def create_arc_env_coord(*args, **kwargs):
+def create_arc_env_coord(
+                        fixed_task: bool, 
+                        fixed_pair_idx: bool,
+                        task_id: str,
+                        pair_idx: int, *args, **kwargs):
     """Factory function to create ARC environment with custom wrapper"""
     base_env = ArcAgiGridEnvCoord(*args, **kwargs)
-    wrapped_env = ArcAgiWrapper(base_env)
+    wrapped_env = ArcAgiWrapper(base_env, 
+                                fixed_task, 
+                                fixed_pair_idx,
+                                task_id,
+                                pair_idx,)
     return wrapped_env
 
 

--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -226,9 +226,6 @@ def load_challenges_and_solutions(
     return training_challenges, training_solutions, \
             evaluation_challenges, evaluation_solutions, test_challenges
                 
-# self.train_task_img_dict, self.train_task_seq_dict = preprocess_data(self.training_challenges, self.training_solutions)
-# self.eval_task_img_dict, self.eval_task_seq_dict = preprocess_data(self.evaluation_challenges, self.evaluation_solutions)
-
 class ArcAgiGridEnvCoord(ArcAgiGridEnv):
     def __init__(self,
                 training_challenges,
@@ -288,16 +285,13 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         pair_idx = None
         if options != None:
             mode = options['mode']
-            task_id = options['task_id']
-            pair_idx = options['pair_idx']
+            self.task_id = options['task_id']
+            self.pair_idx = options['pair_idx']
             reset_sol_grid = options['reset_sol_grid']
-            self.task_id = task_id
-            self.pair_idx = pair_idx
     
         self.timestep = 0
         if task_id == None:
-            task_id = self._select_task(seed)
-            self.task_id = task_id
+            self.task_id = self._select_task(seed)
             
         self.episode_returns = 0
         self.episode_lengths = 0
@@ -314,19 +308,19 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         random.seed(seed)
         np.random.seed(seed)
         # task_id에 해당하는 target grid 선택 (test input이 여러 개 존재 가능하므로 한 번 더 random.choice 수행
-        if pair_idx == None:
+        if self.pair_idx == None:
             if mode == 'train':
-                pair_idx = random.choice(list(range(len(self.train_task_img_dict[task_id]))))
-                self._target_grid_img = self.train_task_img_dict[task_id][pair_idx]
+                self.pair_idx = random.choice(list(range(len(self.train_task_img_dict[self.task_id]))))
+                self._target_grid_img = self.train_task_img_dict[self.task_id][self.pair_idx]
             elif mode == 'evaluation' or mode == 'eval':
-                pair_idx = random.choice(list(range(len(self.eval_task_img_dict[task_id]))))
-                self._target_grid_img = self.eval_task_img_dict[task_id][pair_idx]
+                self.pair_idx = random.choice(list(range(len(self.eval_task_img_dict[self.task_id]))))
+                self._target_grid_img = self.eval_task_img_dict[self.task_id][self.pair_idx]
         else:
             if mode == 'train':
-                self._target_grid_img = self.train_task_img_dict[task_id][pair_idx]
+                self._target_grid_img = self.train_task_img_dict[self.task_id][self.pair_idx]
             elif mode == 'evaluation' or mode == 'eval':
-                self._target_grid_img = self.eval_task_img_dict[task_id][pair_idx]
-        self.test_input_idx = pair_idx
+                self._target_grid_img = self.eval_task_img_dict[self.task_id][self.pair_idx]
+        self.test_input_idx = self.pair_idx
         # target grid에서 test solution에 해당하는 부분을 전부 pad_val으로 masking하고 current grid로 할당
         if reset_sol_grid == 'padding':
             empty_val = 11

--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -3,6 +3,7 @@ from typing import Optional
 import numpy as np
 import gymnasium as gym
 from gymnasium import Wrapper
+from gymnasium.wrappers import Autoreset
 from itertools import permutations, product
 import json
 from typing import Tuple, Dict, Union, List, Any
@@ -276,6 +277,8 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             'test_input_idx': self.test_input_idx,
             "current_grid_img": self._current_grid_img,
             "chosen_grid_img": self._chosen_grid_img,
+            "episode_returns": self.episode_returns,
+            "episode_lengths": self.episode_lengths,
         }
 
     def reset(self,
@@ -296,6 +299,8 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             task_id = self._select_task(seed)
             self.task_id = task_id
             
+        self.episode_returns = 0
+        self.episode_lengths = 0
         """
         Args:
             seed: Random seed for reproducible episodes
@@ -388,6 +393,9 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         observation = self._get_obs()
         info = self._get_info()
         self.timestep += 1
+        self.episode_returns += reward
+        self.episode_lengths += 1
+        
         return observation, reward, terminated, truncated, info
 
     def plot_chosen_grid(self,):

--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -654,9 +654,6 @@ def vectorized_action_converter(actions: torch.Tensor) -> dict:
     # 결과를 딕셔너리로 반환
     result = {
         'colors': colors.numpy(),
-        'rows': rows.numpy(), 
-        'cols': cols.numpy(),
         'coordinates': torch.stack([rows, cols], dim=-1).numpy()  # (N, 2) 형태
     }
-    
     return result

--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -653,7 +653,7 @@ def vectorized_action_converter(actions: torch.Tensor) -> dict:
     
     # 결과를 딕셔너리로 반환
     result = {
-        'colors': colors.numpy(),
-        'coordinates': torch.stack([rows, cols], dim=-1).numpy()  # (N, 2) 형태
+        'color': colors.numpy(),
+        'coordinate': torch.stack([rows, cols], dim=-1).numpy()  # (N, 2) 형태
     }
     return result

--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -11,6 +11,7 @@ from matplotlib import colors
 import matplotlib.pyplot as plt
 import random
 from matplotlib.colors import ListedColormap, Normalize
+import torch 
 
 cmap = colors.ListedColormap(
     [
@@ -631,3 +632,31 @@ def action_converter(action: int) -> dict:
                    'coordinate': coordinate}
     return dict_action
     
+
+def vectorized_action_converter(actions: torch.Tensor) -> dict:
+    """벡터화된 함수 (텐서용)"""
+    # 입력 검증
+    assert torch.all((actions >= 0) & (actions < 9900)), "All actions must be in range [0, 9900)"
+    
+    # 벡터화된 계산
+    # color = action // 900
+    colors = torch.div(actions, 900, rounding_mode='floor')
+    
+    # remainder = action - 900 * color  
+    remainders = actions - 900 * colors
+    
+    # row = remainder // 30
+    rows = torch.div(remainders, 30, rounding_mode='floor')
+    
+    # col = remainder % 30
+    cols = remainders % 30
+    
+    # 결과를 딕셔너리로 반환
+    result = {
+        'colors': colors.numpy(),
+        'rows': rows.numpy(), 
+        'cols': cols.numpy(),
+        'coordinates': torch.stack([rows, cols], dim=-1).numpy()  # (N, 2) 형태
+    }
+    
+    return result

--- a/RL_ARC_AGI/config/ppo_one_task.yaml
+++ b/RL_ARC_AGI/config/ppo_one_task.yaml
@@ -1,0 +1,46 @@
+# Environment configuration
+environment:
+  training_challenges_json: "../datasets/arc-agi_training_challenges.json"
+  training_solutions_json: "../datasets/arc-agi_training_solutions.json"
+  evaluation_challenges_json: "../datasets/arc-agi_evaluation_challenges.json"
+  evaluation_solutions_json: "../datasets/arc-agi_evaluation_solutions.json"
+  test_challenges_json: "../datasets/arc-agi_test_challenges.json"
+  reset_sol_grid: "padding"
+  normalize_obs: false
+  reward_shaping: false
+  task_id_list: ['794b24be', ] # 3cd86f4f, 794b24be
+  fixed_task: true
+  fixed_pair_idx: true
+  task_id: '3cd86f4f'
+  pair_idx: 0
+  seed: 42
+
+# Training configuration
+training:
+  num_updates: 50000
+  rollout_steps: 600
+  mini_batch_size: 128
+  ppo_epochs: 4
+  learning_rate: 3e-4
+  gamma: 0.99
+  gae_lambda: 0.95
+  eps_clip: 0.2
+  value_coef: 1.0
+  entropy_coef: 0.01
+
+# Network configuration
+network:
+  type: vit
+  hidden_size: 256
+
+# Logging and saving configuration
+logging:
+  log_interval: 1
+  eval_interval: 50
+  eval_episodes: 10
+  save_interval: 100
+  save_dir: "models"
+  visualize_period: 2
+  use_wandb: true
+  use_tensorboard: true
+  wandb_project: "arc_agi_ppo"

--- a/RL_ARC_AGI/config/ppo_vector_env.yaml
+++ b/RL_ARC_AGI/config/ppo_vector_env.yaml
@@ -1,0 +1,65 @@
+# Environment configuration
+environment:
+  training_challenges_json: "../datasets/arc-agi_training_challenges.json"
+  training_solutions_json: "../datasets/arc-agi_training_solutions.json"
+  evaluation_challenges_json: "../datasets/arc-agi_evaluation_challenges.json"
+  evaluation_solutions_json: "../datasets/arc-agi_evaluation_solutions.json"
+  test_challenges_json: "../datasets/arc-agi_test_challenges.json"
+  reset_sol_grid: "padding"
+  normalize_obs: false
+  reward_shaping: false
+  task_id_list: ['794b24be', '3cd86f4f'] # Multiple tasks for varied training
+  fixed_task: true
+  fixed_pair_idx: true
+  task_id: '3cd86f4f'
+  pair_idx: 0
+  seed: 42
+  
+  # Vectorized environment specific settings
+  num_envs: 4  # Number of parallel environments
+  num_steps: 128  # Number of steps per environment per rollout
+
+# Training configuration
+training:
+  total_timesteps: 500000  # Total training timesteps
+  rollout_steps: 512  # Total steps across all environments per update (num_envs * num_steps)
+  mini_batch_size: 64  # Smaller mini-batches for vectorized training
+  ppo_epochs: 4
+  learning_rate: 2.5e-4  # Standard PPO learning rate
+  gamma: 0.99
+  gae_lambda: 0.95
+  eps_clip: 0.2
+  value_coef: 0.5
+  entropy_coef: 0.01
+  max_grad_norm: 0.5
+  anneal_lr: true  # Learning rate annealing
+  
+  # Additional PPO hyperparameters for vectorized training
+  norm_adv: true  # Advantage normalization
+  clip_vloss: true  # Value function clipping
+  target_kl: null  # Target KL divergence (null means no early stopping)
+  num_minibatches: 16  # Number of mini-batches for optimization
+
+# Network configuration
+network:
+  type: vit
+  hidden_size: 256
+  # Vision Transformer specific parameters
+  patch_size: 15
+  embed_dim: 768
+  num_heads: 12
+  num_layers: 12
+  mlp_ratio: 4
+  dropout: 0.1
+
+# Logging and saving configuration
+logging:
+  log_interval: 1
+  eval_interval: 100
+  eval_episodes: 10
+  save_interval: 500
+  save_dir: "models/vectorized"
+  visualize_period: 2
+  use_wandb: true
+  use_tensorboard: true
+  wandb_project: "arc_agi_ppo_vectorized"

--- a/RL_ARC_AGI/syncvector_env.py
+++ b/RL_ARC_AGI/syncvector_env.py
@@ -82,17 +82,17 @@ def make_env(fixed_task: bool,
              ):
     def thunk():
         env = create_arc_env_coord(
-            fixed_task=True, 
-            fixed_pair_idx=False,
-            task_id='3cd86f4f', # '3cd86f4f'
-            pair_idx=None,# 0
-            training_challenges="../datasets/arc-agi_training_challenges.json",
-            training_solutions="../datasets/arc-agi_training_solutions.json", 
-            evaluation_challenges="../datasets/arc-agi_evaluation_challenges.json",
-            evaluation_solutions="../datasets/arc-agi_evaluation_solutions.json",
-            test_challenges="../datasets/arc-agi_test_challenges.json",
-            train_task_img_dict=train_task_img_dict,
-            eval_task_img_dict=eval_task_img_dict,
+                fixed_task=True, 
+                fixed_pair_idx=True,
+                task_id='794b24be',
+                pair_idx=None,
+                training_challenges=training_challenges,
+                training_solutions=training_solutions, 
+                evaluation_challenges=evaluation_solutions,
+                evaluation_solutions=evaluation_solutions,
+                test_challenges=test_challenges,
+                train_task_img_dict=train_task_img_dict,
+                eval_task_img_dict=eval_task_img_dict,
             )
         # env = gym.wrappers.RecordEpisodeStatistics(env)
         return env

--- a/RL_ARC_AGI/syncvector_env.py
+++ b/RL_ARC_AGI/syncvector_env.py
@@ -57,6 +57,7 @@ test_sol.shape
 # %%
 env.plot_current_grid()
 # %%
+total_reward = 0
 for t in range(900):
     row = t // 30
     col = t % 30
@@ -64,7 +65,7 @@ for t in range(900):
               'coordinate': [row, col]
               }
     
-    if t > 898:
+    if t > 899:
         action = env.action_space.sample()
         print(f"last action: {action}")
     print(action)

--- a/RL_ARC_AGI/syncvector_env.py
+++ b/RL_ARC_AGI/syncvector_env.py
@@ -1,0 +1,182 @@
+# %%
+import gymnasium as gym 
+from arc_agi_grid_env_coord import ArcAgiGridEnvCoord, \
+                                    ArcAgiWrapper, \
+                                    create_arc_env_coord, \
+                                    load_challenges_and_solutions, \
+                                    preprocess_data
+from gymnasium.envs.registration import register, registry
+import torch 
+
+# %%
+training_challenges_json="../datasets/arc-agi_training_challenges.json"
+training_solutions_json="../datasets/arc-agi_training_solutions.json" 
+evaluation_challenges_json="../datasets/arc-agi_evaluation_challenges.json"
+evaluation_solutions_json="../datasets/arc-agi_evaluation_solutions.json"
+test_challenges_json="../datasets/arc-agi_test_challenges.json"
+
+# %%
+training_challenges, training_solutions, evaluation_challenges, \
+evaluation_solutions, test_challenges = load_challenges_and_solutions(
+                                        training_challenges_json,
+                                        training_solutions_json,
+                                        evaluation_challenges_json,
+                                        evaluation_solutions_json,
+                                        test_challenges_json,
+                                    )
+
+train_task_img_dict, _ = preprocess_data(training_challenges, training_solutions)
+eval_task_img_dict, _ = preprocess_data(evaluation_challenges, evaluation_solutions)
+
+
+# %%
+env = create_arc_env_coord(
+        fixed_task=True, 
+        fixed_pair_idx=True,
+        task_id='794b24be',
+        pair_idx=None,
+        training_challenges=training_challenges,
+        training_solutions=training_solutions, 
+        evaluation_challenges=evaluation_solutions,
+        evaluation_solutions=evaluation_solutions,
+        test_challenges=test_challenges,
+        train_task_img_dict=train_task_img_dict,
+        eval_task_img_dict=eval_task_img_dict,
+    )
+# %%
+# options = {'mode': 'train',
+#            'task_id': '794b24be', # 794b24be, 3cd86f4f
+#            'reset_sol_grid': 'padding',}
+obs, info = env.reset(seed=12,)
+                        # options=options)
+test_sol = env.unwrapped._target_grid_img[:30,150:]
+total_reward = 0
+env.plot_target_grid()
+# %%
+test_sol.shape
+# %%
+env.plot_current_grid()
+# %%
+for t in range(900):
+    row = t // 30
+    col = t % 30
+    action = {'color': test_sol[row, col],
+              'coordinate': [row, col]
+              }
+    
+    if t > 898:
+        action = env.action_space.sample()
+        print(f"last action: {action}")
+    print(action)
+    next_obs, reward, terminated, truncated, info = env.step(action)
+    print(f"timestep {t}: {reward}, {terminated}, {truncated}")
+    total_reward += reward
+    if terminated or truncated: 
+        break
+env.plot_current_grid()
+# %%
+def make_env(fixed_task: bool, 
+             fixed_pair_idx: bool, 
+             task_id: str, 
+             pair_idx: int,
+             ):
+    def thunk():
+        env = create_arc_env_coord(
+            fixed_task=True, 
+            fixed_pair_idx=False,
+            task_id='3cd86f4f', # '3cd86f4f'
+            pair_idx=None,# 0
+            training_challenges="../datasets/arc-agi_training_challenges.json",
+            training_solutions="../datasets/arc-agi_training_solutions.json", 
+            evaluation_challenges="../datasets/arc-agi_evaluation_challenges.json",
+            evaluation_solutions="../datasets/arc-agi_evaluation_solutions.json",
+            test_challenges="../datasets/arc-agi_test_challenges.json",
+            train_task_img_dict=train_task_img_dict,
+            eval_task_img_dict=eval_task_img_dict,
+            )
+        # env = gym.wrappers.RecordEpisodeStatistics(env)
+        return env
+    return thunk
+
+# %%
+num_envs = 4
+envs = gym.vector.SyncVectorEnv(
+    [make_env(True, True, '794b24be', 0) for i in range(num_envs)],
+)
+# %%
+seed = 4
+options = {'mode': 'train',
+           'task_id': '794b24be', # 794b24be, 3cd86f4f
+           'reset_sol_grid': 'padding',}
+next_obs, _ = envs.reset(seed=seed,)
+# # %%
+next_obs.shape
+num_rollout_steps = 128
+for step in range(num_rollout_steps):
+    action = envs.action_space.sample()
+    next_obs, reward, terminations, truncations, infos = envs.step(action)
+    print(action)
+    print(next_obs)
+    # break
+
+
+# %%
+import matplotlib.pyplot as plt
+from matplotlib import colors
+
+cmap = colors.ListedColormap(
+    ['#000000', # 0: black
+     '#0074D9', # 1: blue
+     '#FF4136', # 2: red
+     '#2ECC40', # 3: green
+     '#FFDC00', # 4: yello
+     '#8B00FF', # 5: gray
+     '#F012BE', # 6: magenta
+     '#FF851B', # 7: oragne
+     '#7FDBFF', # 8: sky
+     '#870C25', # 9: brwon
+     '#AAAAAA', # 10: mask
+     '#FFFFFF', # 11: empty
+     ])
+norm = colors.Normalize(vmin=0, vmax=11)
+for i in range(4):
+    w = 0.5
+    input_matrix = next_obs[i]
+    plt.imshow(input_matrix, cmap=cmap, norm=norm)
+    plt.setp(plt.gcf().get_axes(), xticklabels=[], yticklabels=[])
+    '''Grid:'''
+    plt.grid(visible= True, which = 'both', color = '#666666', linewidth = w)
+    plt.tick_params(axis='both', color='none', length=0)
+    '''sub title:'''
+    plt.show()
+
+# %%
+import numpy as np 
+for i in range(0, 4):
+    if i == 3:
+        break
+    print(np.unique(next_obs[i] == next_obs[i+1]))
+# %%
+np.unique(next_obs[1] == next_obs[2])
+# %%
+np.unique(next_obs[1] == next_obs[2])
+# %%
+plt.imshow(next_obs[0][:3, :3], cmap=cmap, norm=norm)
+
+# %%
+plt.imshow(next_obs[1][:3, :3], cmap=cmap, norm=norm)
+# %%
+plt.imshow(next_obs[2][:3, :3], cmap=cmap, norm=norm)
+# %%
+plt.imshow(next_obs[3][:3, :3], cmap=cmap, norm=norm)
+
+# %%
+envs.envs[0].plot_target_grid()
+# %%
+envs.envs[1].plot_target_grid()
+# %%
+envs.envs[2].plot_target_grid()
+# %%
+envs.envs[3].plot_target_grid()
+
+# %%

--- a/RL_ARC_AGI/test_action_converter.py
+++ b/RL_ARC_AGI/test_action_converter.py
@@ -1,5 +1,5 @@
 # %%
-from arc_agi_grid_env_coord import action_converter
+from arc_agi_grid_env_coord import action_converter, vectorized_action_converter
 
 dict_action = action_converter(0)
 print(dict_action)
@@ -20,3 +20,8 @@ import torch
 action = torch.tensor(899)
 dict_action = action_converter(action.cpu().item())
 print(dict_action)
+
+# %%
+action = torch.tensor([899, 1899, 3899, 9899])
+
+# %%

--- a/RL_ARC_AGI/test_action_converter.py
+++ b/RL_ARC_AGI/test_action_converter.py
@@ -22,6 +22,10 @@ dict_action = action_converter(action.cpu().item())
 print(dict_action)
 
 # %%
-action = torch.tensor([899, 1899, 3899, 9899])
+v_action = torch.tensor([899, 1899, 3899, 9899])
 
+# %%
+dict_v_action = vectorized_action_converter(v_action)
+# %%
+dict_v_action
 # %%

--- a/RL_ARC_AGI/train_ppo.py
+++ b/RL_ARC_AGI/train_ppo.py
@@ -20,7 +20,9 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 # Import our modules
 from arc_agi_grid_env_coord import ArcAgiGridEnvCoord, create_arc_env_coord, \
-                                    action_converter
+                                    action_converter, \
+                                    load_challenges_and_solutions, \
+                                    preprocess_data
 from ppo_agent import PPOAgent
 from matplotlib import colors
 from pathlib import Path
@@ -37,15 +39,43 @@ class ArcAgiTrainer:
     def setup_environment(self):
         """Setup the training environment."""
         # Create base environment
-        self.env = create_arc_env_coord(
-            training_challenges_json=self.config.environment.training_challenges_json,
-            training_solutions_json=self.config.environment.training_solutions_json,
-            evaluation_challenges_json=self.config.environment.evaluation_challenges_json,
-            evaluation_solutions_json=self.config.environment.evaluation_solutions_json,
-            test_challenges_json=self.config.environment.test_challenges_json
-            )
+        training_challenges_json="../datasets/arc-agi_training_challenges.json"
+        training_solutions_json="../datasets/arc-agi_training_solutions.json" 
+        evaluation_challenges_json="../datasets/arc-agi_evaluation_challenges.json"
+        evaluation_solutions_json="../datasets/arc-agi_evaluation_solutions.json"
+        test_challenges_json="../datasets/arc-agi_test_challenges.json"
+
+        training_challenges, training_solutions, evaluation_challenges, \
+        evaluation_solutions, test_challenges = load_challenges_and_solutions(
+                                                training_challenges_json,
+                                                training_solutions_json,
+                                                evaluation_challenges_json,
+                                                evaluation_solutions_json,
+                                                test_challenges_json,
+                                            )
+        train_task_img_dict, _ = preprocess_data(training_challenges, training_solutions)
+        eval_task_img_dict, _ = preprocess_data(evaluation_challenges, evaluation_solutions)
+
         self.task_id_list = list(self.config.environment.task_id_list)
         self.seed = self.config.environment.seed
+        self.fixed_task = self.config.environment.fixed_task
+        self.fixed_pair_idx = self.config.environment.fixed_pair_idx
+        self.task_id = self.config.environment.task_id
+        self.pair_idx = self.config.environment.pair_idx
+        
+        self.env = create_arc_env_coord(
+                    fixed_task=self.fixed_task, 
+                    fixed_pair_idx=self.fixed_pair_idx,
+                    task_id=self.task_id,
+                    pair_idx=self.pair_idx,
+                    training_challenges=training_challenges,
+                    training_solutions=training_solutions, 
+                    evaluation_challenges=evaluation_solutions,
+                    evaluation_solutions=evaluation_solutions,
+                    test_challenges=test_challenges,
+                    train_task_img_dict=train_task_img_dict,
+                    eval_task_img_dict=eval_task_img_dict,
+                )
 
         print(f"Environment created successfully!")
         print(f"Observation space: {self.env.observation_space}")
@@ -421,7 +451,7 @@ class ArcAgiTrainer:
             self.tensorboard_writer.close()
 
 
-@hydra.main(version_base=None, config_path="config", config_name="ppo")
+@hydra.main(version_base=None, config_path="config", config_name="ppo_one_task")
 def main(cfg: DictConfig) -> None:
     """Main training function with Hydra configuration."""
     print("Training configuration:")

--- a/RL_ARC_AGI/train_ppo_parallel.py
+++ b/RL_ARC_AGI/train_ppo_parallel.py
@@ -1,0 +1,581 @@
+import os
+import sys
+import random
+import time
+import math
+from typing import Dict, List, Any
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import gymnasium as gym
+from collections import deque
+import hydra
+from omegaconf import DictConfig, OmegaConf
+import wandb
+import matplotlib.pyplot as plt
+from torch.utils.tensorboard import SummaryWriter
+from torch.distributions.categorical import Categorical
+from network.mlp import ActorCritic_MLP
+from network.vit import ActorCritic_ViT
+from arc_agi_grid_env_coord import cmap
+# Add current directory to Python path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# Import our modules
+from arc_agi_grid_env_coord import ArcAgiGridEnvCoord, create_arc_env_coord, \
+                                    action_converter, vectorized_action_converter, \
+                                    load_challenges_and_solutions, \
+                                    preprocess_data
+from matplotlib import colors
+from pathlib import Path
+
+
+def make_env(fixed_task: bool, 
+             fixed_pair_idx: bool, 
+             task_id: str, 
+             pair_idx: int,
+             training_challenges,
+             training_solutions,
+             evaluation_challenges,
+             evaluation_solutions,
+             test_challenges,
+             train_task_img_dict,
+             eval_task_img_dict):
+    """Create and wrap environment for vectorized training."""
+    def thunk():
+        env = create_arc_env_coord(
+                fixed_task=fixed_task, 
+                fixed_pair_idx=fixed_pair_idx,
+                task_id=task_id,
+                pair_idx=pair_idx,
+                training_challenges=training_challenges,
+                training_solutions=training_solutions, 
+                evaluation_challenges=evaluation_challenges,
+                evaluation_solutions=evaluation_solutions,
+                test_challenges=test_challenges,
+                train_task_img_dict=train_task_img_dict,
+                eval_task_img_dict=eval_task_img_dict,
+            )
+        # env = gym.wrappers.RecordEpisodeStatistics(env)
+        return env
+    return thunk
+
+
+class Agent(nn.Module):
+    """Vision Transformer based Actor-Critic network for PPO with grid observations."""
+    
+    def __init__(self, cfg,):
+        super().__init__()
+        if cfg.network.type == 'vit':
+            self.ac_network = ActorCritic_ViT()
+    
+    def forward(self, x):
+        """Forward pass returning CLS token representation."""
+        # Patch embedding
+        action_logits, state_value = self.ac_network(x)
+        return action_logits, state_value 
+       
+    def get_value(self, x):
+        _, state_value = self.forward(x)
+        return state_value
+
+    def get_action_and_value(self, x, action=None):
+        action_logits, state_value = self.forward(x)
+        probs = Categorical(logits=action_logits)
+        if action is None:
+            action = probs.sample()
+        return action, probs.log_prob(action), probs.entropy(), state_value
+
+
+class ArcAgiVectorizedTrainer:
+    """Trainer class for PPO with vectorized ArcAgiGrid environments."""
+    
+    def __init__(self, config: DictConfig):
+        self.config = config
+        self.setup_environment()
+        self.setup_agent()
+        self.setup_logging()
+        self.setup_storage()
+        
+    def setup_environment(self):
+        """Setup the vectorized training environments."""
+        # Load data
+        training_challenges_json = "../datasets/arc-agi_training_challenges.json"
+        training_solutions_json = "../datasets/arc-agi_training_solutions.json" 
+        evaluation_challenges_json = "../datasets/arc-agi_evaluation_challenges.json"
+        evaluation_solutions_json = "../datasets/arc-agi_evaluation_solutions.json"
+        test_challenges_json = "../datasets/arc-agi_test_challenges.json"
+
+        training_challenges, training_solutions, evaluation_challenges, \
+        evaluation_solutions, test_challenges = load_challenges_and_solutions(
+                                                training_challenges_json,
+                                                training_solutions_json,
+                                                evaluation_challenges_json,
+                                                evaluation_solutions_json,
+                                                test_challenges_json,
+                                            )
+        train_task_img_dict, _ = preprocess_data(training_challenges, training_solutions)
+        eval_task_img_dict, _ = preprocess_data(evaluation_challenges, evaluation_solutions)
+
+        self.task_id_list = list(self.config.environment.task_id_list)
+        self.seed = self.config.environment.seed
+        self.fixed_task = self.config.environment.fixed_task
+        self.fixed_pair_idx = self.config.environment.fixed_pair_idx
+        self.task_id = self.config.environment.task_id
+        self.pair_idx = self.config.environment.pair_idx
+        self.num_envs = self.config.environment.num_envs
+        self.num_steps = self.config.environment.num_steps
+        
+        # Create vectorized environment
+        self.envs = gym.vector.SyncVectorEnv([
+            make_env(
+                fixed_task=self.fixed_task,
+                fixed_pair_idx=self.fixed_pair_idx,
+                task_id=self.task_id,
+                pair_idx=self.pair_idx,
+                training_challenges=training_challenges,
+                training_solutions=training_solutions,
+                evaluation_challenges=evaluation_challenges,
+                evaluation_solutions=evaluation_solutions,
+                test_challenges=test_challenges,
+                train_task_img_dict=train_task_img_dict,
+                eval_task_img_dict=eval_task_img_dict
+            ) for i in range(self.num_envs)
+        ])
+
+        print(f"Vectorized environments created successfully!")
+        print(f"Number of environments: {self.num_envs}")
+        print(f"Single observation space: {self.envs.single_observation_space}")
+        print(f"Single action space: {self.envs.single_action_space}")
+        
+    def setup_agent(self):
+        """Setup the PPO agent."""
+        # Calculate action space size
+        obs_size = np.prod(self.envs.single_observation_space.shape)
+        action_size = 9900 # 10 colors * 30x30 coordinate space = 9000
+        
+        print(f"setup_agent. obs_size: {obs_size}, action_size: {action_size}")
+        
+        # Set device
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+        # Create agent
+        self.agent = Agent(self.config).to(self.device)
+        
+        # Create optimizer
+        self.optimizer = optim.Adam(
+            self.agent.parameters(), 
+            lr=self.config.training.learning_rate, 
+            eps=1e-5
+        )
+        
+        print(f"PPO Agent created with device: {self.device}")
+        
+    def setup_logging(self):
+        """Setup logging and metrics tracking."""
+        self.episode_rewards = deque(maxlen=100)
+        self.episode_lengths = deque(maxlen=100)
+        self.success_rate = deque(maxlen=100)
+        
+        # Create save directory
+        os.makedirs(self.config.logging.save_dir, exist_ok=True)
+        
+        # Initialize wandb logger
+        if self.config.logging.use_wandb:
+            run_name = f"ppo_vectorized_{self.task_id}_{int(time.time())}"
+            wandb.init(
+                project=self.config.logging.wandb_project,
+                config=OmegaConf.to_container(self.config, resolve=True),
+                name=run_name,
+                sync_tensorboard=True,
+                monitor_gym=True,
+                save_code=True
+            )
+        
+        # Initialize tensorboard logger
+        if self.config.logging.use_tensorboard:
+            run_name = f"ppo_vectorized_{self.task_id}_{int(time.time())}"
+            self.tensorboard_writer = SummaryWriter(f"runs/{run_name}")
+            self.tensorboard_writer.add_text(
+                "hyperparameters",
+                "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in OmegaConf.to_container(self.config, resolve=True).items()])),
+            )
+        else:
+            self.tensorboard_writer = None
+    
+    def setup_storage(self):
+        """Setup storage for rollout data."""
+        self.obs = torch.zeros((self.num_steps, self.num_envs) + (30, 180)).to(self.device)
+        self.actions = torch.zeros((self.num_steps, self.num_envs)).to(self.device)
+        self.logprobs = torch.zeros((self.num_steps, self.num_envs)).to(self.device)
+        self.rewards = torch.zeros((self.num_steps, self.num_envs)).to(self.device)
+        self.dones = torch.zeros((self.num_steps, self.num_envs)).to(self.device)
+        self.values = torch.zeros((self.num_steps, self.num_envs)).to(self.device)
+        
+        # Manual episode tracking
+        self.current_episode_returns = np.zeros(self.num_envs)
+        self.current_episode_lengths = np.zeros(self.num_envs)
+    
+    def visualize_grid(self, iteration: int, w=0.5, first=False):
+        """Visualize current grid state and log to wandb/tensorboard."""
+        try:
+            norm = colors.Normalize(vmin=0, vmax=11)
+            # Get current grid from first environment
+            info_dict = self.envs.envs[0]._get_info()
+            target_grid = info_dict['target_grid_img']
+            current_grid = info_dict['current_grid_img']
+            timestep = info_dict['timestep']
+            task_id = info_dict['task_id']
+            test_input_idx = info_dict['test_input_idx']
+            
+            test_sol_current_mat = current_grid[:, 120:]
+            test_sol_target_mat = target_grid[:, 120:]
+                
+            if first:
+                plt.imshow(test_sol_target_mat, cmap=cmap, norm=norm)
+                plt.grid(True, which='both', color='lightgrey', linewidth=1.0)
+                plt.setp(plt.gcf().get_axes(), xticklabels=[], yticklabels=[])
+                plt.grid(visible=True, which='both', color='#666666', linewidth=w)
+                plt.xticks([x-0.5 for x in range(1 + len(test_sol_target_mat[0]))])
+                plt.yticks([x-0.5 for x in range(1 + len(test_sol_target_mat))])
+                plt.tick_params(axis='both', color='none', length=0)
+                plt.title(f'task: #{task_id}  test_input_idx: #{test_input_idx}', fontsize=12, color='#000000')
+                figure_folder_path = Path("./figures")
+                if not figure_folder_path.exists():
+                    figure_folder_path.mkdir(parents=True)
+                plt.savefig(f"./figures/target.png")
+                plt.close()
+
+            plt.imshow(test_sol_current_mat, cmap=cmap, norm=norm)
+            plt.grid(True, which='both', color='lightgrey', linewidth=1.0)
+            plt.setp(plt.gcf().get_axes(), xticklabels=[], yticklabels=[])
+            plt.grid(visible=True, which='both', color='#666666', linewidth=w)
+            plt.xticks([x-0.5 for x in range(1 + len(test_sol_current_mat[0]))])
+            plt.yticks([x-0.5 for x in range(1 + len(test_sol_current_mat))])
+            plt.tick_params(axis='both', color='none', length=0)
+            plt.title(f'task: #{task_id}  test_input_idx: #{test_input_idx}  iter: #{iteration}  timestep: #{timestep}', 
+                     fontsize=12, color='#000000')
+            figure_folder_path = Path("./figures")
+            if not figure_folder_path.exists():
+                figure_folder_path.mkdir(parents=True)
+            plt.savefig(f"./figures/{iteration}_current.png")
+            plt.close()
+            
+        except Exception as e:
+            print(f"Warning: Could not visualize grid at iteration {iteration}: {e}")
+        
+    def collect_rollouts(self, iteration: int):
+        """Collect rollout data for training using vectorized environments."""
+        # Reset environments
+        next_obs, _ = self.envs.reset(seed=self.seed)
+        next_obs = torch.Tensor(next_obs).to(self.device)
+        next_done = torch.zeros(self.num_envs).to(self.device)
+        
+        # Reset episode tracking
+        self.current_episode_returns = np.zeros(self.num_envs)
+        self.current_episode_lengths = np.zeros(self.num_envs)
+        
+        for step in range(self.num_steps):
+            self.obs[step] = next_obs
+            self.dones[step] = next_done
+
+            # ALGO LOGIC: action logic
+            with torch.no_grad():
+                action, logprob, _, value = self.agent.get_action_and_value(next_obs)
+                self.values[step] = value.flatten()
+            self.actions[step] = action
+            self.logprobs[step] = logprob
+
+            # Execute actions in vectorized environment
+            dict_action = vectorized_action_converter(action.cpu())
+            # print(f'step: {step}. {dict_action}')
+            next_obs, reward, terminations, truncations, infos = self.envs.step(dict_action)
+            next_done = np.logical_or(terminations, truncations)
+            self.rewards[step] = torch.tensor(reward).to(self.device).view(-1)
+            next_obs, next_done = torch.Tensor(next_obs).to(self.device), torch.Tensor(next_done).to(self.device)
+            
+            # Update episode tracking
+            self.current_episode_returns += reward
+            self.current_episode_lengths += 1
+            
+            # Log episode statistics when episodes end
+            for i in range(self.num_envs):
+                if terminations[i] or truncations[i]:
+                    # Episode ended - log stats
+                    self.episode_rewards.append(self.current_episode_returns[i])
+                    self.episode_lengths.append(self.current_episode_lengths[i])
+                    self.success_rate.append(1.0 if self.current_episode_returns[i] > 10.0 else 0.0)
+                    
+                    # Reset tracking for this environment
+                    self.current_episode_returns[i] = 0.0
+                    self.current_episode_lengths[i] = 0
+        
+        # Bootstrap value for the next state
+        with torch.no_grad():
+            next_value = self.agent.get_value(next_obs).reshape(1, -1)
+            
+        return next_value
+
+    def compute_gae(self, next_value):
+        """Compute Generalized Advantage Estimation."""
+        with torch.no_grad():
+            advantages = torch.zeros_like(self.rewards).to(self.device)
+            lastgaelam = 0
+            for t in reversed(range(self.num_steps)):
+                if t == self.num_steps - 1:
+                    nextnonterminal = 1.0 - self.dones[t]
+                    nextvalues = next_value
+                else:
+                    nextnonterminal = 1.0 - self.dones[t + 1]
+                    nextvalues = self.values[t + 1]
+                delta = self.rewards[t] + self.config.training.gamma * nextvalues * nextnonterminal - self.values[t]
+                advantages[t] = lastgaelam = delta + self.config.training.gamma * self.config.training.gae_lambda * nextnonterminal * lastgaelam
+            returns = advantages + self.values
+            
+        return advantages, returns
+
+    def update_agent(self, advantages, returns, global_step):
+        """Update the agent using PPO."""
+        # Flatten the batch
+        batch_size = self.num_envs * self.num_steps
+        b_obs = self.obs.reshape((-1,) + self.envs.single_observation_space.shape)
+        b_logprobs = self.logprobs.reshape(-1)
+        b_actions = self.actions.reshape(-1)
+        b_advantages = advantages.reshape(-1)
+        b_returns = returns.reshape(-1)
+        b_values = self.values.reshape(-1)
+
+        # Optimizing the policy and value network
+        b_inds = np.arange(batch_size)
+        clipfracs = []
+        
+        for epoch in range(self.config.training.ppo_epochs):
+            np.random.shuffle(b_inds)
+            for start in range(0, batch_size, self.config.training.mini_batch_size):
+                end = start + self.config.training.mini_batch_size
+                mb_inds = b_inds[start:end]
+
+                _, newlogprob, entropy, newvalue = self.agent.get_action_and_value(b_obs[mb_inds], b_actions.long()[mb_inds])
+                logratio = newlogprob - b_logprobs[mb_inds]
+                ratio = logratio.exp()
+
+                with torch.no_grad():
+                    # calculate approx_kl http://joschu.net/blog/kl-approx.html
+                    old_approx_kl = (-logratio).mean()
+                    approx_kl = ((ratio - 1) - logratio).mean()
+                    clipfracs += [((ratio - 1.0).abs() > self.config.training.eps_clip).float().mean().item()]
+
+                mb_advantages = b_advantages[mb_inds]
+                if self.config.training.norm_adv:
+                    mb_advantages = (mb_advantages - mb_advantages.mean()) / (mb_advantages.std() + 1e-8)
+
+                # Policy loss
+                pg_loss1 = -mb_advantages * ratio
+                pg_loss2 = -mb_advantages * torch.clamp(ratio, 1 - self.config.training.eps_clip, 1 + self.config.training.eps_clip)
+                pg_loss = torch.max(pg_loss1, pg_loss2).mean()
+
+                # Value loss
+                newvalue = newvalue.view(-1)
+                if self.config.training.clip_vloss:
+                    v_loss_unclipped = (newvalue - b_returns[mb_inds]) ** 2
+                    v_clipped = b_values[mb_inds] + torch.clamp(
+                        newvalue - b_values[mb_inds],
+                        -self.config.training.eps_clip,
+                        self.config.training.eps_clip,
+                    )
+                    v_loss_clipped = (v_clipped - b_returns[mb_inds]) ** 2
+                    v_loss_max = torch.max(v_loss_unclipped, v_loss_clipped)
+                    v_loss = 0.5 * v_loss_max.mean()
+                else:
+                    v_loss = 0.5 * ((newvalue - b_returns[mb_inds]) ** 2).mean()
+
+                entropy_loss = entropy.mean()
+                loss = pg_loss - self.config.training.entropy_coef * entropy_loss + v_loss * self.config.training.value_coef
+
+                self.optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(self.agent.parameters(), self.config.training.max_grad_norm)
+                self.optimizer.step()
+
+            if self.config.training.target_kl is not None and approx_kl > self.config.training.target_kl:
+                break
+
+        # Calculate explained variance
+        y_pred, y_true = b_values.cpu().numpy(), b_returns.cpu().numpy()
+        var_y = np.var(y_true)
+        explained_var = np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y
+
+        return {
+            'policy_loss': pg_loss.item(),
+            'value_loss': v_loss.item(),
+            'entropy_loss': entropy_loss.item(),
+            'old_approx_kl': old_approx_kl.item(),
+            'approx_kl': approx_kl.item(),
+            'clipfrac': np.mean(clipfracs),
+            'explained_variance': explained_var
+        }
+
+    def train(self):
+        """Main training loop."""
+        print("Starting PPO vectorized training...")
+        print(f"Configuration: {self.config}")
+        
+        # Calculate training parameters
+        batch_size = self.num_envs * self.num_steps
+        num_iterations = self.config.training.total_timesteps // batch_size
+        
+        print(f"Batch size: {batch_size}")
+        print(f"Number of iterations: {num_iterations}")
+        
+        global_step = 0
+        start_time = time.time()
+        best_mean_reward = -float('inf')
+        first_vis = True
+        
+        for iteration in range(1, num_iterations + 1):
+            # Annealing learning rate
+            if self.config.training.anneal_lr:
+                frac = 1.0 - (iteration - 1.0) / num_iterations
+                lrnow = frac * self.config.training.learning_rate
+                self.optimizer.param_groups[0]["lr"] = lrnow
+            
+            # Collect rollouts
+            next_value = self.collect_rollouts(iteration)
+            
+            # Compute GAE
+            advantages, returns = self.compute_gae(next_value)
+            
+            # Update global step
+            global_step += batch_size
+            
+            # Update agent
+            training_metrics = self.update_agent(advantages, returns, global_step)
+            
+            # Logging
+            if iteration % self.config.logging.log_interval == 0:
+                mean_reward = np.mean(self.episode_rewards) if self.episode_rewards else 0
+                mean_length = np.mean(self.episode_lengths) if self.episode_lengths else 0
+                success_rate = np.mean(self.success_rate) if self.success_rate else 0
+                sps = int(global_step / (time.time() - start_time))
+                
+                print(f"\nIteration {iteration}/{num_iterations}")
+                print(f"Global step: {global_step}")
+                print(f"Mean reward (last 100 episodes): {mean_reward:.3f}")
+                print(f"Mean episode length: {mean_length:.1f}")
+                print(f"Success rate: {success_rate:.3f}")
+                print(f"SPS: {sps}")
+                print(f"Learning rate: {self.optimizer.param_groups[0]['lr']:.6f}")
+                
+                if training_metrics:
+                    print(f"Policy loss: {training_metrics['policy_loss']:.4f}")
+                    print(f"Value loss: {training_metrics['value_loss']:.4f}")
+                    print(f"Entropy loss: {training_metrics['entropy_loss']:.4f}")
+                    print(f"Explained variance: {training_metrics['explained_variance']:.4f}")
+                
+                # Log to wandb
+                if self.config.logging.use_wandb:
+                    log_dict = {
+                        'charts/learning_rate': self.optimizer.param_groups[0]['lr'],
+                        'charts/episodic_return': mean_reward,
+                        'charts/episodic_length': mean_length,
+                        'charts/SPS': sps,
+                        'losses/policy_loss': training_metrics['policy_loss'],
+                        'losses/value_loss': training_metrics['value_loss'],
+                        'losses/entropy': training_metrics['entropy_loss'],
+                        'losses/old_approx_kl': training_metrics['old_approx_kl'],
+                        'losses/approx_kl': training_metrics['approx_kl'],
+                        'losses/clipfrac': training_metrics['clipfrac'],
+                        'losses/explained_variance': training_metrics['explained_variance']
+                    }
+                    wandb.log(log_dict, step=global_step)
+                
+                # Log to tensorboard
+                if self.tensorboard_writer:
+                    self.tensorboard_writer.add_scalar('charts/learning_rate', self.optimizer.param_groups[0]['lr'], global_step)
+                    self.tensorboard_writer.add_scalar('charts/episodic_return', mean_reward, global_step)
+                    self.tensorboard_writer.add_scalar('charts/episodic_length', mean_length, global_step)
+                    self.tensorboard_writer.add_scalar('charts/SPS', sps, global_step)
+                    self.tensorboard_writer.add_scalar('losses/policy_loss', training_metrics['policy_loss'], global_step)
+                    self.tensorboard_writer.add_scalar('losses/value_loss', training_metrics['value_loss'], global_step)
+                    self.tensorboard_writer.add_scalar('losses/entropy', training_metrics['entropy_loss'], global_step)
+                    self.tensorboard_writer.add_scalar('losses/old_approx_kl', training_metrics['old_approx_kl'], global_step)
+                    self.tensorboard_writer.add_scalar('losses/approx_kl', training_metrics['approx_kl'], global_step)
+                    self.tensorboard_writer.add_scalar('losses/clipfrac', training_metrics['clipfrac'], global_step)
+                    self.tensorboard_writer.add_scalar('losses/explained_variance', training_metrics['explained_variance'], global_step)
+            
+            # Visualization
+            if iteration % self.config.logging.visualize_period == 0:
+                print(f"Creating grid visualization at iteration {iteration}...")
+                self.visualize_grid(iteration, first=first_vis)
+                first_vis = False
+            
+            # Save checkpoint
+            if iteration % self.config.logging.save_interval == 0 and iteration > 0:
+                checkpoint_path = os.path.join(self.config.logging.save_dir, f'checkpoint_{iteration}.pth')
+                torch.save({
+                    'agent_state_dict': self.agent.state_dict(),
+                    'optimizer_state_dict': self.optimizer.state_dict(),
+                    'iteration': iteration,
+                    'global_step': global_step,
+                    'config': self.config
+                }, checkpoint_path)
+                print(f"Checkpoint saved: {checkpoint_path}")
+                
+                # Save best model if performance improved
+                if mean_reward > best_mean_reward:
+                    best_mean_reward = mean_reward
+                    best_path = os.path.join(self.config.logging.save_dir, 'best_model.pth')
+                    torch.save({
+                        'agent_state_dict': self.agent.state_dict(),
+                        'optimizer_state_dict': self.optimizer.state_dict(),
+                        'iteration': iteration,
+                        'global_step': global_step,
+                        'config': self.config,
+                        'best_reward': best_mean_reward
+                    }, best_path)
+                    print(f"New best model saved! Mean reward: {best_mean_reward:.3f}")
+        
+        print("Training completed!")
+        
+        # Final save
+        final_path = os.path.join(self.config.logging.save_dir, 'final_model.pth')
+        torch.save({
+            'agent_state_dict': self.agent.state_dict(),
+            'optimizer_state_dict': self.optimizer.state_dict(),
+            'iteration': num_iterations,
+            'global_step': global_step,
+            'config': self.config
+        }, final_path)
+        print(f"Final model saved: {final_path}")
+        
+        # Close loggers
+        if self.config.logging.use_wandb:
+            wandb.finish()
+        
+        if self.tensorboard_writer:
+            self.tensorboard_writer.close()
+        
+        self.envs.close()
+
+
+@hydra.main(version_base=None, config_path="config", config_name="ppo_vector_env")
+def main(cfg: DictConfig) -> None:
+    """Main training function with Hydra configuration."""
+    print("Vectorized PPO Training configuration:")
+    print(OmegaConf.to_yaml(cfg))
+    
+    # Set random seeds for reproducibility
+    random.seed(cfg.environment.seed)
+    np.random.seed(cfg.environment.seed)
+    torch.manual_seed(cfg.environment.seed)
+    torch.backends.cudnn.deterministic = True
+    
+    # Create trainer and start training
+    trainer = ArcAgiVectorizedTrainer(cfg)
+    trainer.train()
+
+
+if __name__ == '__main__':
+    main()

--- a/RL_ARC_AGI/train_ppo_parallel.py
+++ b/RL_ARC_AGI/train_ppo_parallel.py
@@ -290,7 +290,6 @@ class ArcAgiVectorizedTrainer:
 
             # Execute actions in vectorized environment
             dict_action = vectorized_action_converter(action.cpu())
-            # print(f'step: {step}. {dict_action}')
             next_obs, reward, terminations, truncations, infos = self.envs.step(dict_action)
             next_done = np.logical_or(terminations, truncations)
             self.rewards[step] = torch.tensor(reward).to(self.device).view(-1)


### PR DESCRIPTION
environment 내의 grid_seq 멤버변수 삭제 

syncvector_env.py에서 사용법 확인

벡터환경을 위해 전처리 함수를 환경 밖에서 호출하고 전처리된 데이터를 환경에 입력으로 받도록 변경

ppo_one_task.yaml에 task_id와 pair_idx 항목이 들어감
이 두 가지를 고정하면 하나의 task에서 하나의 train_test_pair XYXYXY 를 고정하게 됨.
pair_idx를 None 으로 바꾸면 한 task 내의 여러 pair들을 랜덤으로 선택하게 됨. task_id, pair_idx 둘 다 None으로 하면 task_id랑 pair_idx 모두 랜덤으로 결정함.

Close #37 
