### PR TITLE
modify success rate and add rand fill function

### DIFF
--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -326,7 +326,6 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             "color_candidate": self.color_candidate,
             "is_success": self.is_success,
             "ratio_fill_correct": self.ratio_fill_correct,
-            "ratio_fill_incorrect": self.ratio_fill_incorrect,
         }
 
     def reset(self,
@@ -404,7 +403,6 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         # Get rand_init option
         self.rand_init: bool = options.get('rand_init', False) if options else False
         self.ratio_fill_correct: float = options.get('ratio_fill_correct', 0.0) if options else 0.0
-        self.ratio_fill_incorrect: float = options.get('ratio_fill_incorrect', 0.0) if options else 0.0
         
         # target grid에서 test solution에 해당하는 부분을 전부 pad_val으로 masking하고 current grid로 할당
         self._chosen_grid_img = np.zeros([30, 30]).astype(int)
@@ -416,38 +414,23 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             height, width = self.size_candidate[0], self.size_candidate[1]
             total_cells = height * width
 
-            assert (self.ratio_fill_correct + self.ratio_fill_incorrect) <= 1.0
+            assert self.ratio_fill_correct < 1.0
 
-            if self.ratio_fill_correct > 0.0 or self.ratio_fill_incorrect > 0.0:
+            if self.ratio_fill_correct > 0.0:
                 # Randomly initialize some cells in size_candidate area with correct answers or incorrect answers
                 target_solution = self._target_grid_img[0:height, 150:150+width]
                 current_solution = np.full((height, width), empty_val)  # Start with empty
-                
-                # 랜덤 값 채우기
-                if self.ratio_fill_incorrect > 0.0:
-                    incorrect_num_filled = int(total_cells * self.ratio_fill_incorrect)
-                    incorrect_positions = [(i, j) for i in range(height) for j in range(width)]
-                    incorrect_filled_positions = np.random.choice(len(incorrect_positions), incorrect_num_filled, replace=False)
-                    for pos_idx in incorrect_filled_positions:
-                        i, j = incorrect_positions[pos_idx]
-                        random_color = np.random.randint(low=0, high=9)
-                        if random_color == target_solution[i, j]:
-                            # 정답으로 채워진 경우, 이미 선택한 것으로 간주함
-                            self._chosen_grid_img[i, j] +=1
-                        current_solution[i, j] = random_color
-                
+
                 # 정답 값 채우기
-                if self.ratio_fill_correct > 0.0:
-                    num_filled = int(total_cells * self.ratio_fill_correct)
-                    positions = [(i, j) for i in range(height) for j in range(width)]
-                    filled_positions = np.random.choice(len(positions), num_filled, replace=False)
-                    for pos_idx in filled_positions:
-                        i, j = positions[pos_idx]
-                        current_solution[i, j] = target_solution[i, j]
-                        # 정답으로 채워진 경우, 이미 선택한 것으로 간주함
-                        self._chosen_grid_img[i, j] +=1
+                num_filled = int(total_cells * self.ratio_fill_correct)
+                positions = [(i, j) for i in range(height) for j in range(width)]
+                filled_positions = np.random.choice(len(positions), num_filled, replace=False)
+                for pos_idx in filled_positions:
+                    i, j = positions[pos_idx]
+                    current_solution[i, j] = target_solution[i, j]
+                    # 정답으로 채워진 경우, 이미 선택한 것으로 간주함
+                    self._chosen_grid_img[i, j] +=1
                 self._current_grid_img[0:height, 150:150+width] = current_solution
-                
 
         else: # self.rand_init == False
             # Fill only the size_candidate area with empty_val (11)
@@ -500,7 +483,7 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             terminated = True
             reward = -1
         # 선택한 위치에 틀린 색을 선택한 경우 실패
-        elif color != target_color_img:
+        elif color != target_color_img or current_cell_value != 11:
             terminated = True
             reward = -1
         else:

--- a/RL_ARC_AGI/arc_agi_grid_env_coord.py
+++ b/RL_ARC_AGI/arc_agi_grid_env_coord.py
@@ -324,23 +324,14 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             "episode_lengths": self.episode_lengths,
             "size_candidate": self.size_candidate,
             "color_candidate": self.color_candidate,
+            "is_success": self.is_success,
+            "ratio_fill_correct": self.ratio_fill_correct,
+            "ratio_fill_incorrect": self.ratio_fill_incorrect,
         }
 
     def reset(self,
               seed: Optional[int] = None,
               options: Optional[dict] = None):
-        if options != None:
-            mode = options['mode']
-            self.task_id = options['task_id']
-            self.pair_idx = options['pair_idx']
-            reset_sol_grid = options['reset_sol_grid']
-    
-        self.timestep = 0
-        if self.task_id == None:
-            self.task_id = self._select_task(seed)
-            
-        self.episode_returns = 0
-        self.episode_lengths = 0
         """
         Args:
             seed: Random seed for reproducible episodes
@@ -349,11 +340,27 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         Returns:
             tuple: (observation, info) for the initial state
         """
+        
+        
+        self.is_success = False
+
+        if options != None:
+            mode = options['mode']
+            self.task_id = options['task_id']
+            self.pair_idx = options['pair_idx']
+    
+        self.timestep = 0
+        if self.task_id == None:
+            self.task_id = self._select_task(seed)
+            
+        self.episode_returns = 0
+        self.episode_lengths = 0
+
         # IMPORTANT: Must call this first to seed the random number generator
         # super().reset(seed=seed)
         random.seed(seed)
         np.random.seed(seed)
-        # task_id에 해당하는 target grid 선택 (test input이 여러 개 존재 가능하므로 한 번 더 random.choice 수행
+        # task_id에 해당하는 target grid 선택 (train input output, test input이 여러 개 존재 가능하므로 한 번 더 random.choice 수행
         if self.pair_idx == None:
             if mode == 'train':
                 self.pair_idx = random.choice(list(range(len(self.train_task_img_dict[self.task_id]))))
@@ -392,55 +399,60 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         if len(valid_colors) == 0:
             raise ValueError("Cannot determine color candidates: no valid colors (0-9) found in solution area")
         self.color_candidate = valid_colors.tolist()
-
+        self.max_sum_reward = 0.05 * (self.size_candidate[0] * self.size_candidate[1] - 1) + 1
+        
         # Get rand_init option
-        rand_init = options.get('rand_init', False) if options else False
+        self.rand_init: bool = options.get('rand_init', False) if options else False
+        self.ratio_fill_correct: float = options.get('ratio_fill_correct', 0.0) if options else 0.0
+        self.ratio_fill_incorrect: float = options.get('ratio_fill_incorrect', 0.0) if options else 0.0
         
         # target grid에서 test solution에 해당하는 부분을 전부 pad_val으로 masking하고 current grid로 할당
-        if reset_sol_grid == 'padding':
-            empty_val = 11
-            self._current_grid_img = self._target_grid_img.copy()
+        self._chosen_grid_img = np.zeros([30, 30]).astype(int)
+        empty_val = 11
+        self._current_grid_img = self._target_grid_img.copy()
+        if self.rand_init:
             # Fill the solution area with different values based on size_candidate
             self._current_grid_img[0:30, 150:] = 10  # Fill entire solution area with 10 first
-            
             height, width = self.size_candidate[0], self.size_candidate[1]
-            
-            if rand_init:
-                # 20% chance to start with completely empty grid
-                if np.random.random() < 0.2:
-                    # Fill only the size_candidate area with empty_val (11)
-                    self._current_grid_img[0:height, 150:150+width] = empty_val
-                else:
-                    # Randomly initialize some cells in size_candidate area with correct answers
-                    target_solution = self._target_grid_img[0:height, 150:150+width]
-                    current_solution = np.full((height, width), empty_val)  # Start with empty
-                    
-                    # Randomly fill some percentage of correct answers
-                    fill_ratio = np.random.uniform(0.2, 0.7)  # 20%-70% pre-filled
-                    total_cells = height * width
-                    num_filled = int(total_cells * fill_ratio)
-                    
-                    # Get random positions to fill
+            total_cells = height * width
+
+            assert (self.ratio_fill_correct + self.ratio_fill_incorrect) <= 1.0
+
+            if self.ratio_fill_correct > 0.0 or self.ratio_fill_incorrect > 0.0:
+                # Randomly initialize some cells in size_candidate area with correct answers or incorrect answers
+                target_solution = self._target_grid_img[0:height, 150:150+width]
+                current_solution = np.full((height, width), empty_val)  # Start with empty
+                
+                # 랜덤 값 채우기
+                if self.ratio_fill_incorrect > 0.0:
+                    incorrect_num_filled = int(total_cells * self.ratio_fill_incorrect)
+                    incorrect_positions = [(i, j) for i in range(height) for j in range(width)]
+                    incorrect_filled_positions = np.random.choice(len(incorrect_positions), incorrect_num_filled, replace=False)
+                    for pos_idx in incorrect_filled_positions:
+                        i, j = incorrect_positions[pos_idx]
+                        random_color = np.random.randint(low=0, high=9)
+                        if random_color == target_solution[i, j]:
+                            # 정답으로 채워진 경우, 이미 선택한 것으로 간주함
+                            self._chosen_grid_img[i, j] +=1
+                        current_solution[i, j] = random_color
+                
+                # 정답 값 채우기
+                if self.ratio_fill_correct > 0.0:
+                    num_filled = int(total_cells * self.ratio_fill_correct)
                     positions = [(i, j) for i in range(height) for j in range(width)]
                     filled_positions = np.random.choice(len(positions), num_filled, replace=False)
-                    
                     for pos_idx in filled_positions:
                         i, j = positions[pos_idx]
                         current_solution[i, j] = target_solution[i, j]
-                    
-                    self._current_grid_img[0:height, 150:150+width] = current_solution
-            else:
-                # Fill only the size_candidate area with empty_val (11)
-                self._current_grid_img[0:height, 150:150+width] = empty_val 
-        elif reset_sol_grid == 'random':
-            # ! 여기서 solution에 해당하는 부분을 랜덤으로 초기화해도 좋을듯?
-            rand_grid = np.random.randint(low=0,
-                                            high=11,
-                                            size=(30, 30))
-            self._current_grid_img = self._target_grid_img.copy()
-            self._current_grid_img[0:30, 150:] = rand_grid
+                        # 정답으로 채워진 경우, 이미 선택한 것으로 간주함
+                        self._chosen_grid_img[i, j] +=1
+                self._current_grid_img[0:height, 150:150+width] = current_solution
+                
 
-        self._chosen_grid_img = np.zeros([30, 30]).astype(int)
+        else: # self.rand_init == False
+            # Fill only the size_candidate area with empty_val (11)
+            self._current_grid_img[0:height, 150:150+width] = empty_val
+            
         
         observation = self._get_obs()
         info = self._get_info()
@@ -452,6 +464,8 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
             action: The action to take (0-10)
         Returns:
             tuple: (observation, reward, terminated, truncated, info)
+            
+        step 함수에서 self.total_reward == self.max_reward 인 경우, self.is_success = True로 변경
         """
         color = action['color']
         coordinate = action['coordinate']
@@ -461,9 +475,7 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         
         # 현재 칸의 값 확인 (action을 취하기 전 값)
         current_cell_value = self._current_grid_img[row, 150+col]
-        
         self._current_grid_img[row, 150+col] = color
-        self._chosen_grid_img[row, col] += 1
         
         # Log grid changes occasionally
         if hasattr(self, 'step_counter'):
@@ -483,13 +495,18 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         terminated = False
         truncated = False
 
-        # 잘못된 위치에 칠하거나, 이미 칠해진 곳에 다시 칠한 경우 (실패)
-        if color != target_color_img or current_cell_value != 11:
+        # 이미 선택한 셀을 또 선택하거나, 미리 정답으로 채워져 있는 셀을 선택하는 경우 실패
+        if self._chosen_grid_img[row, col] > 1:
+            terminated = True
+            reward = -1
+        # 선택한 위치에 틀린 색을 선택한 경우 실패
+        elif color != target_color_img:
             terminated = True
             reward = -1
         else:
             # 퍼즐을 완성한 경우
             if np.array_equal(self._current_grid_img, self._target_grid_img):
+                self.is_success = True
                 terminated = True
                 reward = 1
             # 올바른 중간 과정인 경우 (완성은 아직 아님)
@@ -500,7 +517,7 @@ class ArcAgiGridEnvCoord(ArcAgiGridEnv):
         info = self._get_info()
         self.episode_returns += reward
         self.episode_lengths += 1
-        
+        self._chosen_grid_img[row, col] += 1
         return observation, reward, terminated, truncated, info
 
     def plot_chosen_grid(self,):
@@ -643,40 +660,19 @@ class ArcAgiWrapper(Wrapper):
     while maintaining compatibility with Gymnasium's interface.
     """
     
-    def __init__(self, env, 
-                 fixed_task: bool, 
-                 fixed_pair_idx: bool, 
-                task_id: str,
-                pair_idx: int,):
+    def __init__(self, env, ):
         super().__init__(env)
-        self.fixed_task = fixed_task
-        self.fixed_pair_idx = fixed_pair_idx
-        self.task_id = task_id
-        self.pair_idx = pair_idx
-    
+        self.seed = 42
+        self.options = None
+        print(f"init seed: {self.seed}")
+
     def reset(self, *args, **kwargs,):
-        if self.fixed_task and not self.fixed_pair_idx:
-            options = {'mode': 'train',
-                    'task_id': self.task_id, # 794b24be, 3cd86f4f
-                    'pair_idx': None, 
-                    'reset_sol_grid': 'padding',}
-        elif self.fixed_task and self.fixed_pair_idx:
-            options = {'mode': 'train',
-                    'task_id': self.task_id, # 794b24be, 3cd86f4f
-                    'pair_idx': self.pair_idx, 
-                    'reset_sol_grid': 'padding',}
-        elif not self.fixed_task and self.fixed_pair_idx:
-            options = {'mode': 'train',
-                    'task_id': None, # 794b24be, 3cd86f4f
-                    'pair_idx': self.pair_idx, 
-                    'reset_sol_grid': 'padding',}
-        else:
-            options = {'mode': 'train',
-                    'task_id': None, # 794b24be, 3cd86f4f
-                    'pair_idx': None, 
-                    'reset_sol_grid': 'padding',}
-        # task_id를 항상 포함시켜서 reset 호출
-        return self.env.reset(options=options,)
+        if 'seed' in kwargs:
+            self.seed = kwargs['seed']
+            print(f"changed seed: {self.seed}")
+        if 'options' in kwargs:
+            self.options = kwargs['options']
+        return self.env.reset(seed=self.seed, options=self.options,)
     
     def __getattr__(self, name):
         """
@@ -709,19 +705,45 @@ class ArcAgiWrapper(Wrapper):
 
 
 # 사용 예시
-def create_arc_env_coord(
-                        fixed_task: bool, 
-                        fixed_pair_idx: bool,
-                        task_id: str,
-                        pair_idx: int, *args, **kwargs):
+def create_arc_env_coord(training_challenges,
+                        training_solutions,
+                        evaluation_challenges,
+                        evaluation_solutions,
+                        test_challenges,
+                        train_task_img_dict,
+                        eval_task_img_dict):
     """Factory function to create ARC environment with custom wrapper"""
-    base_env = ArcAgiGridEnvCoord(*args, **kwargs)
-    wrapped_env = ArcAgiWrapper(base_env, 
-                                fixed_task, 
-                                fixed_pair_idx,
-                                task_id,
-                                pair_idx,)
+    base_env = ArcAgiGridEnvCoord(training_challenges,
+                                    training_solutions,
+                                    evaluation_challenges,
+                                    evaluation_solutions,
+                                    test_challenges,
+                                    train_task_img_dict,
+                                    eval_task_img_dict)
+    wrapped_env = ArcAgiWrapper(base_env,)
     return wrapped_env
+
+
+def make_env(training_challenges,
+             training_solutions,
+             evaluation_challenges,
+             evaluation_solutions,
+             test_challenges,
+             train_task_img_dict,
+             eval_task_img_dict):
+    """Create and wrap environment for vectorized training."""
+    def thunk():
+        env = create_arc_env_coord(
+                training_challenges=training_challenges,
+                training_solutions=training_solutions,
+                evaluation_challenges=evaluation_challenges,
+                evaluation_solutions=evaluation_solutions,
+                test_challenges=test_challenges,
+                train_task_img_dict=train_task_img_dict,
+                eval_task_img_dict=eval_task_img_dict,
+            )
+        return env
+    return thunk
 
 
 def action_converter(action: int) -> dict:

--- a/RL_ARC_AGI/config/ppo_arc_agi_base.yaml
+++ b/RL_ARC_AGI/config/ppo_arc_agi_base.yaml
@@ -1,0 +1,63 @@
+# Environment configuration
+environment:
+  training_challenges_json: "../datasets/arc-agi_training_challenges.json"
+  training_solutions_json: "../datasets/arc-agi_training_solutions.json"
+  evaluation_challenges_json: "../datasets/arc-agi_evaluation_challenges.json"
+  evaluation_solutions_json: "../datasets/arc-agi_evaluation_solutions.json"
+  test_challenges_json: "../datasets/arc-agi_test_challenges.json"
+  normalize_obs: false
+  reward_shaping: false
+  task_id_list: ['794b24be', '3cd86f4f'] # Multiple tasks for varied training
+  task_id: '3cd86f4f'
+  pair_idx: 0
+  seed: 37
+  rand_init: false
+  ratio_fill_correct: 0.0
+  ratio_fill_incorrect: 0.0
+  
+  # Vectorized environment specific settings
+  num_envs: 4  # Number of parallel environments
+  num_steps: 128  # Number of steps per environment per rollout
+
+# Training configuration
+training:
+  total_timesteps: 500000  # Total training timesteps
+  ppo_epochs: 4
+  learning_rate: 2.5e-4  # Standard PPO learning rate
+  gamma: 0.99
+  gae_lambda: 0.95
+  eps_clip: 0.2
+  value_coef: 0.5
+  entropy_coef: 0.01
+  max_grad_norm: 0.5
+  anneal_lr: true  # Learning rate annealing
+  
+  # Additional PPO hyperparameters for vectorized training
+  norm_adv: true  # Advantage normalization
+  clip_vloss: true  # Value function clipping
+  target_kl: null  # Target KL divergence (null means no early stopping)
+  num_minibatches: 8  # Number of mini-batches for optimization
+
+# Network configuration
+network:
+  type: vit
+  hidden_size: 256
+  # Vision Transformer specific parameters
+  patch_size: 15
+  embed_dim: 768
+  num_heads: 12
+  num_layers: 12
+  mlp_ratio: 4
+  dropout: 0.1
+
+# Logging and saving configuration
+logging:
+  log_interval: 1
+  eval_interval: 100
+  eval_episodes: 10
+  save_interval: 500
+  save_dir: "models/vectorized"
+  visualize_period: 2
+  use_wandb: true
+  use_tensorboard: true
+  wandb_project: "arc_agi_ppo_vectorized"

--- a/RL_ARC_AGI/config/ppo_arc_agi_base.yaml
+++ b/RL_ARC_AGI/config/ppo_arc_agi_base.yaml
@@ -13,7 +13,6 @@ environment:
   seed: 37
   rand_init: false
   ratio_fill_correct: 0.0
-  ratio_fill_incorrect: 0.0
   
   # Vectorized environment specific settings
   num_envs: 4  # Number of parallel environments

--- a/RL_ARC_AGI/test_arc_env_coord.py
+++ b/RL_ARC_AGI/test_arc_env_coord.py
@@ -1,37 +1,61 @@
 # %%
 import gymnasium as gym 
 from arc_agi_grid_env_coord import ArcAgiGridEnvCoord, ArcAgiWrapper, create_arc_env_coord
+from arc_agi_grid_env_coord import create_arc_env_coord, preprocess_data, load_challenges_and_solutions
+from arc_agi_grid_env_coord import convert_dict_to_int, vectorized_convert_dict_to_int, make_env
 from gymnasium.envs.registration import register, registry
 
 # %%
-env = create_arc_env_coord(
-        training_challenges_json="../datasets/arc-agi_training_challenges.json",
-        training_solutions_json="../datasets/arc-agi_training_solutions.json", 
-        evaluation_challenges_json="../datasets/arc-agi_evaluation_challenges.json",
-        evaluation_solutions_json="../datasets/arc-agi_evaluation_solutions.json",
-        test_challenges_json="../datasets/arc-agi_test_challenges.json"
-    )
 
-# 794b24be train input pair 10개
-# 8dab14c2 test input 4개
-# 3cd86f4f
-options = {'mode': 'train',
-           'task_id': '794b24be',
-           'reset_sol_grid': 'padding',}
-obs, info = env.reset(seed=1,
-                      options=options,)
-# obs, info = env.reset(seed=1,
-#                         mode='train',
-#                         task_id='794b24be',
-#                         reset_sol_grid='random')
 
 # %%
-env.print_train_task_info('794b24be')
+training_challenges_json = "../datasets/arc-agi_training_challenges.json"
+training_solutions_json = "../datasets/arc-agi_training_solutions.json"
+evaluation_challenges_json = "../datasets/arc-agi_evaluation_challenges.json"
+evaluation_solutions_json = "../datasets/arc-agi_evaluation_solutions.json"
+test_challenges_json = "../datasets/arc-agi_test_challenges.json"
+
+training_challenges, training_solutions, evaluation_challenges, \
+evaluation_solutions, test_challenges = load_challenges_and_solutions(
+                                        training_challenges_json,
+                                        training_solutions_json,
+                                        evaluation_challenges_json,
+                                        evaluation_solutions_json,
+                                        test_challenges_json,
+                                    )
+train_task_img_dict, _, train_img_shape_colors, _ = preprocess_data(training_challenges, training_solutions)
+eval_task_img_dict, _, eval_img_shape_colors, _= preprocess_data(evaluation_challenges, evaluation_solutions)
+
+# %%
+env = make_env(training_challenges=training_challenges,
+                training_solutions=training_solutions,
+                evaluation_challenges=evaluation_challenges,
+                evaluation_solutions=evaluation_solutions,
+                test_challenges=test_challenges,
+                train_task_img_dict=train_task_img_dict,
+                eval_task_img_dict=eval_task_img_dict,
+                )()
+# %%
+# 3cd86f4f
+# 794b24be train input pair 10개
+# 8dab14c2 test input 4개
+task_id = '794b24be'
+pair_idx = 0
+options = {'mode': 'train',
+        'task_id': task_id,
+        'pair_idx': pair_idx,
+        'rand_init': False,
+        }
+# %%
+obs, info = env.reset(seed=42,
+                      options=options,)
+# %%
+env.print_train_task_info(task_id)
 # %%
 env.plot_current_task_and_sol()
 # %%
 # 264363fd
-env.plot_padded_task(task_id='794b24be', i=0)
+env.plot_padded_task(task_id=task_id, i=0)
 
 # %%
 env.plot_current_grid()
@@ -40,53 +64,109 @@ env.plot_target_grid()
 
 # %%
 env.plot_one_task(mode='train', 
-                task_id='794b24be')
+                task_id=task_id)
 # %%
-env.plot_original_task(task_id='794b24be',
+env.plot_original_task(task_id=task_id,
             train_or_test='test',
-            i=0,
+            i=pair_idx,
+            input_or_output='output',
+            )
+# %%
+task_id = '8dab14c2'
+pair_idx = 0
+# options = {'mode': 'train',
+#         'task_id': task_id,
+#         'pair_idx': pair_idx,
+#         'rand_init': True,
+#         'ratio_fill_correct': 0.5,
+#         'ratio_fill_incorrect': 0.0,
+#         }
+options = {'mode': 'train',
+        'task_id': task_id,
+        'pair_idx': pair_idx,
+        'rand_init': True,
+        'ratio_fill_correct': 0.5,
+        'ratio_fill_incorrect': 0.5,
+        }
+# %%
+obs, info = env.reset(seed=42,
+                      options=options,)
+# %%
+env.print_train_task_info(task_id)
+# %%
+env.plot_current_task_and_sol()
+# %%
+# 264363fd
+env.plot_padded_task(task_id=task_id, i=0)
+
+# %%
+env.plot_current_grid()
+# %%
+env.plot_target_grid()
+
+# %%
+env.plot_one_task(mode='train', 
+                task_id=task_id)
+# %%
+env.plot_original_task(task_id=task_id,
+            train_or_test='test',
+            i=pair_idx,
             input_or_output='output',
             )
 
 # %%
+num_envs = 4
+envs = gym.vector.SyncVectorEnv([
+    make_env(
+        training_challenges=training_challenges,
+        training_solutions=training_solutions,
+        evaluation_challenges=evaluation_challenges,
+        evaluation_solutions=evaluation_solutions,
+        test_challenges=test_challenges,
+        train_task_img_dict=train_task_img_dict,
+        eval_task_img_dict=eval_task_img_dict
+    ) for i in range(num_envs)
+])
+task_id = '3cd86f4f' # 8dab14c2, 794b24be, 3cd86f4f
+# options = {'mode': 'train',
+#         'task_id': task_id,
+#         'pair_idx': pair_idx,
+#         'rand_init': False,
+#         'ratio_fill_correct': 0.0,
+#         'ratio_fill_incorrect': 0.0,
+#         }
+# options = {'mode': 'train',
+#         'task_id': task_id,
+#         'pair_idx': None,
+#         'rand_init': False,
+#         'ratio_fill_correct': 0.0,
+#         'ratio_fill_incorrect': 0.0,
+#         }
 options = {'mode': 'train',
-           'task_id': '794b24be', # 794b24be, 3cd86f4f
-           'reset_sol_grid': 'padding',}
-obs, info = env.reset(seed=12,
-                        options=options)
-test_sol = env.unwrapped._target_grid_seq[4500:]
-total_reward = 0
-
+        'task_id': task_id,
+        'pair_idx': None,
+        'rand_init': True,
+        'ratio_fill_correct': 0.5,
+        'ratio_fill_incorrect': 0.5,
+        }
 # %%
-env.plot_target_grid()
+obs, info = envs.reset(seed=42, options=options)
 # %%
-env.plot_current_grid()
+envs.envs[0].plot_current_grid()
 # %%
-for t in range(900):
-    row = t // 30
-    col = t % 30
-    action = {'color': test_sol[t],
-              'coordinate': [row, col]
-              }
-    
-    if t > 898:
-        action = env.action_space.sample()
-        print(f"last action: {action}")
-    print(action)
-    next_obs, reward, terminated, truncated, info = env.step(action)
-    print(f"timestep {t}: {reward}, {terminated}, {truncated}")
-    total_reward += reward
-    if terminated or truncated: 
-        break
-env.plot_current_grid()
-
-print(round(total_reward, 2))
+envs.envs[0].plot_target_grid()
 # %%
-env.plot_current_grid()
-
+envs.envs[1].plot_current_grid()
 # %%
-env.train_task_img_dict['3cd86f4f'][0].shape
+envs.envs[1].plot_target_grid()
 # %%
-len(env.train_task_img_dict['794b24be'])
-
+envs.envs[2].plot_current_grid()
+# %%
+envs.envs[2].plot_target_grid()
+# %%
+envs.envs[3].plot_current_grid()
+# %%
+envs.envs[3].plot_target_grid()
+# %%
+print(infoinfos)
 # %%

--- a/RL_ARC_AGI/test_arc_env_coord.py
+++ b/RL_ARC_AGI/test_arc_env_coord.py
@@ -79,14 +79,12 @@ pair_idx = 0
 #         'pair_idx': pair_idx,
 #         'rand_init': True,
 #         'ratio_fill_correct': 0.5,
-#         'ratio_fill_incorrect': 0.0,
 #         }
 options = {'mode': 'train',
         'task_id': task_id,
         'pair_idx': pair_idx,
         'rand_init': True,
         'ratio_fill_correct': 0.5,
-        'ratio_fill_incorrect': 0.5,
         }
 # %%
 obs, info = env.reset(seed=42,
@@ -147,7 +145,6 @@ options = {'mode': 'train',
         'pair_idx': None,
         'rand_init': True,
         'ratio_fill_correct': 0.5,
-        'ratio_fill_incorrect': 0.5,
         }
 # %%
 obs, info = envs.reset(seed=42, options=options)
@@ -168,5 +165,6 @@ envs.envs[3].plot_current_grid()
 # %%
 envs.envs[3].plot_target_grid()
 # %%
-print(infoinfos)
+print(info.keys())
 # %%
+info['is_success']

--- a/RL_ARC_AGI/train_ppo_parallel.py
+++ b/RL_ARC_AGI/train_ppo_parallel.py
@@ -565,7 +565,6 @@ class ArcAgiVectorizedTrainer:
                 'pair_idx': self.pair_idx,
                 'rand_init': self.rand_init,
                 'ratio_fill_correct': self.ratio_fill_correct,
-                'ratio_fill_incorrect': self.ratio_fill_incorrect,
                 }
         next_obs, infos = self.envs.reset(seed=self.seed, options=options)
         next_obs = torch.Tensor(next_obs).to(self.device)

--- a/RL_ARC_AGI/train_ppo_parallel.py
+++ b/RL_ARC_AGI/train_ppo_parallel.py
@@ -19,7 +19,7 @@ from torch.utils.tensorboard import SummaryWriter
 from torch.distributions.categorical import Categorical
 from network.mlp import ActorCritic_MLP
 from network.vit import ActorCritic_ViT
-from arc_agi_grid_env_coord import cmap
+from arc_agi_grid_env_coord import cmap, make_env
 # Add current directory to Python path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -80,38 +80,6 @@ def log_action_details(action_tensor, infos, step_num, max_logs=5):
             else:
                 valid_color = "?"
             print(f"    Color validity: {valid_color}")
-
-
-def make_env(fixed_task: bool, 
-             fixed_pair_idx: bool, 
-             task_id: str, 
-             pair_idx: int,
-             training_challenges,
-             training_solutions,
-             evaluation_challenges,
-             evaluation_solutions,
-             test_challenges,
-             train_task_img_dict,
-             eval_task_img_dict):
-    """Create and wrap environment for vectorized training."""
-    def thunk():
-        env = create_arc_env_coord(
-                fixed_task=fixed_task, 
-                fixed_pair_idx=fixed_pair_idx,
-                task_id=task_id,
-                pair_idx=pair_idx,
-                training_challenges=training_challenges,
-                training_solutions=training_solutions, 
-                evaluation_challenges=evaluation_challenges,
-                evaluation_solutions=evaluation_solutions,
-                test_challenges=test_challenges,
-                train_task_img_dict=train_task_img_dict,
-                eval_task_img_dict=eval_task_img_dict,
-            )
-        # env = gym.wrappers.RecordEpisodeStatistics(env)
-        return env
-    return thunk
-
 
 class Agent(nn.Module):
     """Vision Transformer based Actor-Critic network for PPO with grid observations."""
@@ -267,24 +235,27 @@ class ArcAgiVectorizedTrainer:
 
         self.task_id_list = list(self.config.environment.task_id_list)
         self.seed = self.config.environment.seed
-        self.fixed_task = self.config.environment.fixed_task
-        self.fixed_pair_idx = self.config.environment.fixed_pair_idx
-        self.task_id = self.config.environment.task_id
-        self.pair_idx = self.config.environment.pair_idx
+        self.task_id = self.config.environment.task_id # if None task_id is randomly selected
+        self.pair_idx = self.config.environment.pair_idx # if None pair_idx is randomly selected
+        self.rand_init = self.config.environment.rand_init
+        self.ratio_fill_correct = self.config.environment.ratio_fill_correct
+        self.ratio_fill_incorrect = self.config.environment.ratio_fill_incorrect
         self.num_envs = self.config.environment.num_envs
         self.num_steps = self.config.environment.num_steps
         
         # Get size_candidate and color_candidate from config if available
-        self.size_candidate = getattr(self.config.environment, 'size_candidate', [4, 4])
-        self.color_candidate = getattr(self.config.environment, 'color_candidate', [0, 1, 4, 5, 9])
+        if self.task_id != None and self.pair_idx != None:
+            img_shape_color_list = train_img_shape_colors[self.task_id]
+            row = img_shape_color_list[self.pair_idx].row
+            col = img_shape_color_list[self.pair_idx].col
+            size_candidate = [row, col]
+            color_candidate = img_shape_color_list[self.pair_idx].color
+        self.size_candidate = getattr(self.config.environment, 'size_candidate', size_candidate)
+        self.color_candidate = getattr(self.config.environment, 'color_candidate', color_candidate)
         
         # Create vectorized environment
         self.envs = gym.vector.SyncVectorEnv([
             make_env(
-                fixed_task=self.fixed_task,
-                fixed_pair_idx=self.fixed_pair_idx,
-                task_id=self.task_id,
-                pair_idx=self.pair_idx,
                 training_challenges=training_challenges,
                 training_solutions=training_solutions,
                 evaluation_challenges=evaluation_challenges,
@@ -461,8 +432,8 @@ class ArcAgiVectorizedTrainer:
                     # Episode ended - log stats
                     self.episode_returns.append(self.current_episode_returns[i])
                     self.episode_lengths.append(self.current_episode_lengths[i])
-                    self.success_rate.append(1.0 if self.current_episode_returns[i] > 10.0 else 0.0)
-                    
+                    is_success = infos['is_success'][i]
+                    self.success_rate.append(1.0 if is_success else 0.0)
                     # Reset tracking for this environment
                     self.current_episode_returns[i] = 0.0
                     self.current_episode_lengths[i] = 0
@@ -589,11 +560,14 @@ class ArcAgiVectorizedTrainer:
         best_mean_reward = -float('inf')
         first_vis = True
         
-        reset_options = {
-            'size_candidate': self.size_candidate,
-            'color_candidate': self.color_candidate
-        }
-        next_obs, infos = self.envs.reset(seed=self.seed, options=reset_options)
+        options = {'mode': 'train',
+                'task_id': self.task_id,
+                'pair_idx': self.pair_idx,
+                'rand_init': self.rand_init,
+                'ratio_fill_correct': self.ratio_fill_correct,
+                'ratio_fill_incorrect': self.ratio_fill_incorrect,
+                }
+        next_obs, infos = self.envs.reset(seed=self.seed, options=options)
         next_obs = torch.Tensor(next_obs).to(self.device)
         next_done = torch.zeros(self.num_envs).to(self.device)
         
@@ -731,7 +705,7 @@ class ArcAgiVectorizedTrainer:
         self.envs.close()
 
 
-@hydra.main(version_base=None, config_path="config", config_name="ppo_vector_env")
+@hydra.main(version_base=None, config_path="config", config_name="ppo_arc_agi_base")
 def main(cfg: DictConfig) -> None:
     """Main training function with Hydra configuration."""
     print("Vectorized PPO Training configuration:")


### PR DESCRIPTION
arc_agi_grid_env_coord.py에서 
순수히 reset 만을 활용하여 task_id, pair_index, rand_init 등을 정할 수 있도록 변경했습니다. (오프라인 RL에서 데이터셋 생성 관련 이슈로 변경)

#63 
관련하여, 규식님이 추후에 커리큘럼 러닝에 활용하실 수 있도록 rand_init 변수와, ratio_fill_correct, ratio_fill_incorrect 멤버변수를 추가했습니다. 명시적으로 ratio를 바꾸시고 reset 할 때 option에 넣으시면 됩니다. 랜덤으로 초기화를 하는데, 정답 색깔로 초기화하는 경우와, 틀린 색깔로 초기화하는 경우를 추가했습니다. (틀린 색깔을 올바르게 수정하는 법을 배우게 하는 것이 추후 일반화에 도움이 될 것이라 판단했습니다)
test_arc_env_coord.py에서 해당 기능의 변경을 직관적으로 확인할 수 있습니다.
20% 비율이 70% 비율보다 크게 만드는 기능은 나중에 train 함수에서 ratio scheduler를 구현해서 사용하시면 될 것 같습니다. 

#68 
관련하여 환경에서 is_success를 info에 저장하도록 수정했습니다. train_ppo_parallel.py 에서 435번째 줄에서 해당 정보에 접근하고, 성공률에 반영합니다. 

마지막으로 ppo_arc_agi_base.yaml을 추가했습니다. 실험을 돌리실 때 python train_ppo_parallel.py environment.seed=42 environment.task_id=3cd86f4f training.ppo_epochs=4 와 같이 hydra config 오버라이딩을 활용하셔서 실험을 진행하시면 conflict가 나지 않을 것입니다. 

